### PR TITLE
プライバシーポリシーの最終更新日を2026/3/28に更新

### DIFF
--- a/en/privacy/index.html
+++ b/en/privacy/index.html
@@ -178,7 +178,7 @@
 
   <div class="content">
     <h1>Privacy Policy</h1>
-    <span class="updated">Last updated: February 15, 2026</span>
+    <span class="updated">Last updated: March 28, 2026</span>
 
     <p class="intro">Life Hack Tools ("we", "us", or "our") sets forth this Privacy Policy regarding the handling of user information in the applications ("the App") we provide.</p>
 

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -178,7 +178,7 @@
 
   <div class="content">
     <h1>プライバシーポリシー</h1>
-    <span class="updated">最終更新日: 2026年2月15日</span>
+    <span class="updated">最終更新日: 2026年3月28日</span>
 
     <p class="intro">Life Hack Tools（以下「当団体」）は、当団体が提供するアプリケーション（以下「本アプリ」）における利用者の個人情報の取り扱いについて、以下のとおりプライバシーポリシーを定めます。</p>
 

--- a/vi/privacy/index.html
+++ b/vi/privacy/index.html
@@ -178,7 +178,7 @@
 
   <div class="content">
     <h1>Chính sách bảo mật</h1>
-    <span class="updated">Cập nhật lần cuối: 15 tháng 2 năm 2026</span>
+    <span class="updated">Cập nhật lần cuối: 28 tháng 3 năm 2026</span>
 
     <p class="intro">Life Hack Tools (sau đây gọi là "tổ chức") quy định chính sách bảo mật sau đây về việc xử lý thông tin cá nhân của người dùng trong các ứng dụng do tổ chức cung cấp (sau đây gọi là "ứng dụng").</p>
 


### PR DESCRIPTION
## Summary
- JA/EN/VI 全3ページの最終更新日を 2026年3月28日 に変更

Closes #5