### PR TITLE
Tech Stack: i18nextをFrontendに移動 & Claude Code追加

### DIFF
--- a/en/stack/index.html
+++ b/en/stack/index.html
@@ -190,6 +190,11 @@
           <div class="desc">A styling library that brings Tailwind CSS to React Native.</div>
           <div class="apps"><span>StockHome</span><span>TodoBox</span><span>麻雀帖</span></div>
         </div>
+        <div class="stack-card">
+          <div class="name"><span class="icon">🌐</span> i18next</div>
+          <div class="desc">Internationalization framework. Supports Japanese, English, and Vietnamese.</div>
+          <div class="apps"><span>All Apps</span></div>
+        </div>
       </div>
     </div>
 
@@ -247,12 +252,12 @@
     </div>
 
     <div class="category fade-in">
-      <div class="category-title">Localization</div>
+      <div class="category-title">Development</div>
       <div class="stack-grid">
         <div class="stack-card">
-          <div class="name"><span class="icon">🌐</span> i18next</div>
-          <div class="desc">An internationalization framework. Supports Japanese, English, and Vietnamese.</div>
-          <div class="apps"><span>All Apps</span></div>
+          <div class="name"><span class="icon">🤖</span> Claude Code</div>
+          <div class="desc">AI pair programming. Assists with coding, review, and debugging.</div>
+          <div class="apps"><span>All Apps</span><span>lh.tools</span></div>
         </div>
       </div>
     </div>

--- a/stack/index.html
+++ b/stack/index.html
@@ -190,6 +190,11 @@
           <div class="desc">Tailwind CSSをReact Nativeで使えるスタイリングライブラリ。</div>
           <div class="apps"><span>StockHome</span><span>TodoBox</span><span>麻雀帖</span></div>
         </div>
+        <div class="stack-card">
+          <div class="name"><span class="icon">🌐</span> i18next</div>
+          <div class="desc">多言語対応フレームワーク。日本語・英語・ベトナム語をサポート。</div>
+          <div class="apps"><span>全アプリ</span></div>
+        </div>
       </div>
     </div>
 
@@ -247,12 +252,12 @@
     </div>
 
     <div class="category fade-in">
-      <div class="category-title">Localization</div>
+      <div class="category-title">Development</div>
       <div class="stack-grid">
         <div class="stack-card">
-          <div class="name"><span class="icon">🌐</span> i18next</div>
-          <div class="desc">多言語対応フレームワーク。日本語・英語・ベトナム語をサポート。</div>
-          <div class="apps"><span>全アプリ</span></div>
+          <div class="name"><span class="icon">🤖</span> Claude Code</div>
+          <div class="desc">AIペアプログラミング。コーディング・レビュー・デバッグをAIがアシスト。</div>
+          <div class="apps"><span>全アプリ</span><span>lh.tools</span></div>
         </div>
       </div>
     </div>

--- a/vi/stack/index.html
+++ b/vi/stack/index.html
@@ -190,6 +190,11 @@
           <div class="desc">Thư viện styling cho phép sử dụng Tailwind CSS trong React Native.</div>
           <div class="apps"><span>StockHome</span><span>TodoBox</span><span>麻雀帖</span></div>
         </div>
+        <div class="stack-card">
+          <div class="name"><span class="icon">🌐</span> i18next</div>
+          <div class="desc">Framework đa ngôn ngữ. Hỗ trợ tiếng Nhật, tiếng Anh và tiếng Việt.</div>
+          <div class="apps"><span>Tất cả</span></div>
+        </div>
       </div>
     </div>
 
@@ -247,12 +252,12 @@
     </div>
 
     <div class="category fade-in">
-      <div class="category-title">Localization</div>
+      <div class="category-title">Development</div>
       <div class="stack-grid">
         <div class="stack-card">
-          <div class="name"><span class="icon">🌐</span> i18next</div>
-          <div class="desc">Framework đa ngôn ngữ. Hỗ trợ tiếng Nhật, tiếng Anh và tiếng Việt.</div>
-          <div class="apps"><span>Tất cả</span></div>
+          <div class="name"><span class="icon">🤖</span> Claude Code</div>
+          <div class="desc">Lập trình cặp với AI. Hỗ trợ viết code, review và debug.</div>
+          <div class="apps"><span>Tất cả</span><span>lh.tools</span></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- i18nextをLocalizationカテゴリからFrontendカテゴリに移動
- Localizationカテゴリを削除
- Developmentカテゴリを新設、Claude Codeを追加
- JA/EN/VI 全3ページ

Closes #13