### PR TITLE
chore: add app-ads.txt for AdMob

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-7717895563983990, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- AdMob用に `app-ads.txt` をルートに追加
- Publisher ID: pub-7717895563983990

🤖 Generated with [Claude Code](https://claude.com/claude-code)