### PR TITLE
fix: align store badge sizes on mahjong-cho page

### DIFF
--- a/apps/mahjong-cho/index.html
+++ b/apps/mahjong-cho/index.html
@@ -94,6 +94,7 @@
     .hero .cta a { transition: opacity 0.2s; }
     .hero .cta a:hover { opacity: 0.8; }
     .hero .cta img { height: 50px; }
+    .hero .cta img[src*="google-play"] { height: 74px; margin: -12px 0; }
 
     /* Sections */
     .section {
@@ -183,6 +184,7 @@
     .footer-cta .cta a { transition: opacity 0.2s; }
     .footer-cta .cta a:hover { opacity: 0.8; }
     .footer-cta .cta img { height: 50px; }
+    .footer-cta .cta img[src*="google-play"] { height: 74px; margin: -12px 0; }
 
     /* Animations */
     .fade-in {
@@ -209,12 +211,12 @@
 
   <!-- Hero -->
   <div class="hero">
-    <img src="/assets/icon-mahjong-cho.png" alt="麻雀帖" class="hero-icon">
+    <img src="../../assets/icon-mahjong-cho.png" alt="麻雀帖" class="hero-icon">
     <h1>麻雀帖</h1>
     <p class="subtitle">対局を、もっとスマートに記録。</p>
     <div class="cta">
-      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
-      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="/assets/google-play-badge.png" alt="Google Play で手に入れよう" style="height:50px"></a>
+      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="../../assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="../../assets/google-play-badge.png" alt="Google Play で手に入れよう" ></a>
     </div>
   </div>
 
@@ -260,8 +262,8 @@
   <div class="footer-cta fade-in">
     <h2>次の対局から、使ってみよう。</h2>
     <div class="cta">
-      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
-      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="/assets/google-play-badge.png" alt="Google Play で手に入れよう" style="height:50px"></a>
+      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="../../assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="../../assets/google-play-badge.png" alt="Google Play で手に入れよう" ></a>
     </div>
   </div>
 

--- a/en/apps/mahjong-cho/index.html
+++ b/en/apps/mahjong-cho/index.html
@@ -94,6 +94,7 @@
     .hero .cta a { transition: opacity 0.2s; }
     .hero .cta a:hover { opacity: 0.8; }
     .hero .cta img { height: 50px; }
+    .hero .cta img[src*="google-play"] { height: 74px; margin: -12px 0; }
 
     /* Sections */
     .section {
@@ -183,6 +184,7 @@
     .footer-cta .cta a { transition: opacity 0.2s; }
     .footer-cta .cta a:hover { opacity: 0.8; }
     .footer-cta .cta img { height: 50px; }
+    .footer-cta .cta img[src*="google-play"] { height: 74px; margin: -12px 0; }
 
     /* Animations */
     .fade-in {
@@ -209,12 +211,12 @@
 
   <!-- Hero -->
   <div class="hero">
-    <img src="/assets/icon-mahjong-cho.png" alt="Mahjong Cho" class="hero-icon">
+    <img src="../../../assets/icon-mahjong-cho.png" alt="Mahjong Cho" class="hero-icon">
     <h1>Mahjong Cho</h1>
     <p class="subtitle">Record your games, smarter.</p>
     <div class="cta">
-      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
-      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="/assets/google-play-badge.png" alt="Get it on Google Play" style="height:50px"></a>
+      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="../../../assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="../../../assets/google-play-badge.png" alt="Get it on Google Play" ></a>
     </div>
   </div>
 
@@ -260,8 +262,8 @@
   <div class="footer-cta fade-in">
     <h2>Start using it from your next game.</h2>
     <div class="cta">
-      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
-      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="/assets/google-play-badge.png" alt="Get it on Google Play" style="height:50px"></a>
+      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="../../../assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="../../../assets/google-play-badge.png" alt="Get it on Google Play" ></a>
     </div>
   </div>
 

--- a/vi/apps/mahjong-cho/index.html
+++ b/vi/apps/mahjong-cho/index.html
@@ -94,6 +94,7 @@
     .hero .cta a { transition: opacity 0.2s; }
     .hero .cta a:hover { opacity: 0.8; }
     .hero .cta img { height: 50px; }
+    .hero .cta img[src*="google-play"] { height: 74px; margin: -12px 0; }
 
     /* Sections */
     .section {
@@ -183,6 +184,7 @@
     .footer-cta .cta a { transition: opacity 0.2s; }
     .footer-cta .cta a:hover { opacity: 0.8; }
     .footer-cta .cta img { height: 50px; }
+    .footer-cta .cta img[src*="google-play"] { height: 74px; margin: -12px 0; }
 
     /* Animations */
     .fade-in {
@@ -209,12 +211,12 @@
 
   <!-- Hero -->
   <div class="hero">
-    <img src="/assets/icon-mahjong-cho.png" alt="Mahjong Cho" class="hero-icon">
+    <img src="../../../assets/icon-mahjong-cho.png" alt="Mahjong Cho" class="hero-icon">
     <h1>Mahjong Cho</h1>
     <p class="subtitle">Ghi điểm thông minh hơn.</p>
     <div class="cta">
-      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="/assets/app-store-badge.svg" alt="Tải trên App Store"></a>
-      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="/assets/google-play-badge.png" alt="Tải trên Google Play" style="height:50px"></a>
+      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="../../../assets/app-store-badge.svg" alt="Tải trên App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="../../../assets/google-play-badge.png" alt="Tải trên Google Play" ></a>
     </div>
   </div>
 
@@ -260,8 +262,8 @@
   <div class="footer-cta fade-in">
     <h2>Hãy dùng từ trận đấu tiếp theo.</h2>
     <div class="cta">
-      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="/assets/app-store-badge.svg" alt="Tải trên App Store"></a>
-      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="/assets/google-play-badge.png" alt="Tải trên Google Play" style="height:50px"></a>
+      <a href="https://apps.apple.com/jp/app/%E9%BA%BB%E9%9B%80%E5%B8%96/id6756340479"><img src="../../../assets/app-store-badge.svg" alt="Tải trên App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mahjongcho"><img src="../../../assets/google-play-badge.png" alt="Tải trên Google Play" ></a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- App Store / Google Play バッジの表示サイズを揃えた
- 画像パスを絶対パスから相対パスに変更（ローカルプレビュー対応）
- JA / EN / VI 3言語すべて対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)