### PR TITLE
feat: StockHome / Mugg / TodoBox に App Store URL を追加

### DIFF
--- a/apps/mugg/index.html
+++ b/apps/mugg/index.html
@@ -98,7 +98,7 @@
     <h1>Mugg</h1>
     <p class="subtitle">行きつけのカフェを、記録しよう。</p>
     <div class="cta">
-      <span class="coming-soon">Coming Soon</span>
+      <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 
@@ -141,7 +141,7 @@
   <div class="footer-cta fade-in">
     <h2>次のカフェを、Muggしよう。</h2>
     <div class="cta">
-      <span class="coming-soon">Coming Soon</span>
+      <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 

--- a/apps/stockhome/index.html
+++ b/apps/stockhome/index.html
@@ -262,7 +262,7 @@
     <h1>StockHome</h1>
     <p class="subtitle">家庭の在庫、もう忘れない。</p>
     <div class="cta">
-      <span class="coming-soon">リリース準備中</span>
+      <a href="https://apps.apple.com/jp/app/stockhome/id6760977394"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 
@@ -331,7 +331,7 @@
   <div class="footer-cta fade-in">
     <h2>さっそく使ってみよう。</h2>
     <div class="cta">
-      <span class="coming-soon">リリース準備中</span>
+      <a href="https://apps.apple.com/jp/app/stockhome/id6760977394"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 

--- a/apps/todo-box/index.html
+++ b/apps/todo-box/index.html
@@ -230,7 +230,7 @@
     <h1>TodoBox</h1>
     <p class="subtitle">やること、それだけ。</p>
     <div class="cta">
-      <span class="coming-soon">リリース準備中</span>
+      <a href="https://apps.apple.com/jp/app/todobox/id6761283158"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 
@@ -277,7 +277,7 @@
   <div class="footer-cta fade-in">
     <h2>今日のやることを、書き出そう。</h2>
     <div class="cta">
-      <span class="coming-soon">リリース準備中</span>
+      <a href="https://apps.apple.com/jp/app/todobox/id6761283158"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 

--- a/en/apps/mugg/index.html
+++ b/en/apps/mugg/index.html
@@ -94,7 +94,7 @@
     <h1>Mugg</h1>
     <p class="subtitle">Log your favorite cafes.</p>
     <div class="cta">
-      <span class="coming-soon">Coming Soon</span>
+      <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 
@@ -137,7 +137,7 @@
   <div class="footer-cta fade-in">
     <h2>Mugg your next cafe.</h2>
     <div class="cta">
-      <span class="coming-soon">Coming Soon</span>
+      <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 

--- a/en/apps/stockhome/index.html
+++ b/en/apps/stockhome/index.html
@@ -262,7 +262,7 @@
     <h1>StockHome</h1>
     <p class="subtitle">Never forget your household inventory.</p>
     <div class="cta">
-      <span class="coming-soon">Coming Soon</span>
+      <a href="https://apps.apple.com/jp/app/stockhome/id6760977394"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 
@@ -331,7 +331,7 @@
   <div class="footer-cta fade-in">
     <h2>Try it out now.</h2>
     <div class="cta">
-      <span class="coming-soon">Coming Soon</span>
+      <a href="https://apps.apple.com/jp/app/stockhome/id6760977394"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 

--- a/en/apps/todo-box/index.html
+++ b/en/apps/todo-box/index.html
@@ -230,7 +230,7 @@
     <h1>TodoBox</h1>
     <p class="subtitle">Your tasks. That's it.</p>
     <div class="cta">
-      <span class="coming-soon">Coming Soon</span>
+      <a href="https://apps.apple.com/jp/app/todobox/id6761283158"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 
@@ -277,7 +277,7 @@
   <div class="footer-cta fade-in">
     <h2>Write down today's tasks.</h2>
     <div class="cta">
-      <span class="coming-soon">Coming Soon</span>
+      <a href="https://apps.apple.com/jp/app/todobox/id6761283158"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 

--- a/vi/apps/mugg/index.html
+++ b/vi/apps/mugg/index.html
@@ -94,7 +94,7 @@
     <h1>Mugg</h1>
     <p class="subtitle">Ghi lại quán cafe yêu thích của bạn.</p>
     <div class="cta">
-      <span class="coming-soon">Coming Soon</span>
+      <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 
@@ -137,7 +137,7 @@
   <div class="footer-cta fade-in">
     <h2>Mugg quán cafe tiếp theo của bạn.</h2>
     <div class="cta">
-      <span class="coming-soon">Coming Soon</span>
+      <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 

--- a/vi/apps/stockhome/index.html
+++ b/vi/apps/stockhome/index.html
@@ -262,7 +262,7 @@
     <h1>StockHome</h1>
     <p class="subtitle">Không bao giờ quên đồ trong nhà.</p>
     <div class="cta">
-      <span class="coming-soon">Sắp ra mắt</span>
+      <a href="https://apps.apple.com/jp/app/stockhome/id6760977394"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 
@@ -331,7 +331,7 @@
   <div class="footer-cta fade-in">
     <h2>Hãy dùng thử ngay.</h2>
     <div class="cta">
-      <span class="coming-soon">Sắp ra mắt</span>
+      <a href="https://apps.apple.com/jp/app/stockhome/id6760977394"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 

--- a/vi/apps/todo-box/index.html
+++ b/vi/apps/todo-box/index.html
@@ -230,7 +230,7 @@
     <h1>TodoBox</h1>
     <p class="subtitle">Việc cần làm, chỉ vậy thôi.</p>
     <div class="cta">
-      <span class="coming-soon">Sắp ra mắt</span>
+      <a href="https://apps.apple.com/jp/app/todobox/id6761283158"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 
@@ -277,7 +277,7 @@
   <div class="footer-cta fade-in">
     <h2>Hãy viết ra việc cần làm hôm nay.</h2>
     <div class="cta">
-      <span class="coming-soon">Sắp ra mắt</span>
+      <a href="https://apps.apple.com/jp/app/todobox/id6761283158"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- StockHome（id6760977394）、Mugg（id6761840660）、TodoBox（id6761283158）の App Store 公開に伴い、各ページのストアボタンを更新
- ヒーローセクションとフッター CTA の「リリース準備中 / Coming Soon / Sắp ra mắt」を App Store バッジリンクに差し替え
- 3アプリ × 3言語（ja / en / vi）= 9ファイル更新
- Play Store は引き続き内部テスト段階のため変更なし

Closes #29

## Test plan

- [ ] https://lh.tools/apps/stockhome/ — App Store バッジが表示され、タップで App Store に遷移する
- [ ] https://lh.tools/en/apps/stockhome/ — 同上（英語版）
- [ ] https://lh.tools/vi/apps/stockhome/ — 同上（ベトナム語版）
- [ ] https://lh.tools/apps/mugg/ — App Store バッジが表示され、タップで App Store に遷移する
- [ ] https://lh.tools/en/apps/mugg/ — 同上（英語版）
- [ ] https://lh.tools/vi/apps/mugg/ — 同上（ベトナム語版）
- [ ] https://lh.tools/apps/todo-box/ — App Store バッジが表示され、タップで App Store に遷移する
- [ ] https://lh.tools/en/apps/todo-box/ — 同上（英語版）
- [ ] https://lh.tools/vi/apps/todo-box/ — 同上（ベトナム語版）

🤖 Generated with [Claude Code](https://claude.com/claude-code)