### PR TITLE
feat: MuggとLife CalendarにGoogle Playバッジ追加

### DIFF
--- a/apps/life-calendar/index.html
+++ b/apps/life-calendar/index.html
@@ -214,6 +214,7 @@
     <p class="subtitle">人生を、一目で見渡す。</p>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/life-calendar/id6760540958"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=com.lhkyoko.lifecalendar"><img src="/assets/google-play-badge.png" alt="Google Play で手に入れよう"></a>
     </div>
   </div>
 
@@ -261,6 +262,7 @@
     <h2>今週から、はじめよう。</h2>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/life-calendar/id6760540958"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=com.lhkyoko.lifecalendar"><img src="/assets/google-play-badge.png" alt="Google Play で手に入れよう"></a>
     </div>
   </div>
 

--- a/apps/mugg/index.html
+++ b/apps/mugg/index.html
@@ -99,6 +99,7 @@
     <p class="subtitle">行きつけのカフェを、記録しよう。</p>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mugg"><img src="/assets/google-play-badge.png" alt="Google Play で手に入れよう"></a>
     </div>
   </div>
 
@@ -142,6 +143,7 @@
     <h2>次のカフェを、Muggしよう。</h2>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mugg"><img src="/assets/google-play-badge.png" alt="Google Play で手に入れよう"></a>
     </div>
   </div>
 

--- a/en/apps/life-calendar/index.html
+++ b/en/apps/life-calendar/index.html
@@ -214,6 +214,7 @@
     <p class="subtitle">See your entire life at a glance.</p>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/life-calendar/id6760540958"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=com.lhkyoko.lifecalendar"><img src="/assets/google-play-badge.png" alt="Get it on Google Play"></a>
     </div>
   </div>
 
@@ -261,6 +262,7 @@
     <h2>Start this week.</h2>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/life-calendar/id6760540958"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=com.lhkyoko.lifecalendar"><img src="/assets/google-play-badge.png" alt="Get it on Google Play"></a>
     </div>
   </div>
 

--- a/en/apps/mugg/index.html
+++ b/en/apps/mugg/index.html
@@ -95,6 +95,7 @@
     <p class="subtitle">Log your favorite cafes.</p>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mugg"><img src="/assets/google-play-badge.png" alt="Get it on Google Play"></a>
     </div>
   </div>
 
@@ -138,6 +139,7 @@
     <h2>Mugg your next cafe.</h2>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mugg"><img src="/assets/google-play-badge.png" alt="Get it on Google Play"></a>
     </div>
   </div>
 

--- a/vi/apps/life-calendar/index.html
+++ b/vi/apps/life-calendar/index.html
@@ -214,6 +214,7 @@
     <p class="subtitle">Nhìn lại cuộc đời trong một cái nhìn.</p>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/life-calendar/id6760540958"><img src="/assets/app-store-badge.svg" alt="Tải trên App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=com.lhkyoko.lifecalendar"><img src="/assets/google-play-badge.png" alt="Get it on Google Play"></a>
     </div>
   </div>
 
@@ -261,6 +262,7 @@
     <h2>Bắt đầu từ tuần này.</h2>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/life-calendar/id6760540958"><img src="/assets/app-store-badge.svg" alt="Tải trên App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=com.lhkyoko.lifecalendar"><img src="/assets/google-play-badge.png" alt="Get it on Google Play"></a>
     </div>
   </div>
 

--- a/vi/apps/mugg/index.html
+++ b/vi/apps/mugg/index.html
@@ -95,6 +95,7 @@
     <p class="subtitle">Ghi lại quán cafe yêu thích của bạn.</p>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mugg"><img src="/assets/google-play-badge.png" alt="Get it on Google Play"></a>
     </div>
   </div>
 
@@ -138,6 +139,7 @@
     <h2>Mugg quán cafe tiếp theo của bạn.</h2>
     <div class="cta">
       <a href="https://apps.apple.com/jp/app/mugg/id6761840660"><img src="/assets/app-store-badge.svg" alt="Download on the App Store"></a>
+      <a href="https://play.google.com/store/apps/details?id=tools.lh.mugg"><img src="/assets/google-play-badge.png" alt="Get it on Google Play"></a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Mugg（JA/EN/VI）にGoogle Playバッジを追加
- Life Calendar（JA/EN/VI）にGoogle Playバッジを追加
- 各ページのヒーロー・フッターCTAの計2箇所ずつ

## Play Store URLs
- Mugg: https://play.google.com/store/apps/details?id=tools.lh.mugg
- Life Calendar: https://play.google.com/store/apps/details?id=com.lhkyoko.lifecalendar